### PR TITLE
Default `withCUDA` based on whether CUDA package is functional

### DIFF
--- a/controlgetlineageABCdynamics.jl
+++ b/controlgetlineageABCdynamics.jl
@@ -40,7 +40,7 @@ function controlgetlineageABCdynamics(;
     comment = something(comment, "for_m2extrasmalltestdata")
     auxiliaryfoldertrunkname::String="Auxfiles"
     useRAM = something(useRAM, true)
-    withCUDA = something(withCUDA, false)
+    withCUDA = something(withCUDA, CUDA.functional())
     without = something(without, 1)
     withwriteoutputtext = something(withwriteoutputtext, true)
 


### PR DESCRIPTION
This is a small change that was suggested in one of our last meetings: we can make the default value of `withCUDA` depend on whether CUDA is actually available at runtime.  This is the approach [recommended in `CUDA.jl` documentation](https://cuda.juliagpu.org/stable/installation/conditional/#Scenario-2:-GPU-is-optional)