### PR TITLE
Add a command line interface for track conversion

### DIFF
--- a/docs/tracking_formats.md
+++ b/docs/tracking_formats.md
@@ -8,7 +8,7 @@ This tool is compatible with the output of the following software:
 
 or any files in the [cell tracking challenge format](https://celltrackingchallenge.net/datasets/).
 
-Instructions for exporting the required files from each are provided below:
+# Exporting the required files
 
 ## TrackMate
 
@@ -85,3 +85,44 @@ The tool expects the standard `.h5` output from btrack e.g. from
 If your files are already in the cell tracking challenge format, then no further conversion is necessary. The tool only 
 requires the txt file representing an acyclic graph for the whole video (e.g. `man_track.txt` / `res_track.txt`).
 
+# Running the track converter CLI
+
+To convert/validate your tracks, you will first need to install the required python dependencies.
+
+- Clone the repository
+```bash
+git clone https://github.com/Jamie-Dean-Lab/Lineage-analysis.git
+```
+
+- Inside the cloned repo, run:
+```bash
+pip install -e .
+```
+
+To run the tool, make sure you are inside `/track_converter/src` then:
+```bash
+python convert_tracks.py --help
+```
+
+The tool has one command per file format, to see the help for each run:
+```bash
+# For btrack files...
+python convert_tracks.py btrack --help
+
+# For trackmate files...
+python convert_tracks.py trackmate --help
+
+# For mamut files...
+python convert_tracks.py mamut --help
+
+# For mastodon files...
+python convert_tracks.py mastodon --help
+
+# For cell tracking challenge (CTC) files...
+python convert_tracks.py ctc --help
+```
+
+An example call for a btrack file:
+```bash
+python convert_tracks.py btrack tracks.h5 --no-terminate-fates --dead-track-ids "[53, 49, 38]"
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,9 +15,9 @@ classifiers = [
     "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
-  "pandas",
-  "btrack",
-  "click",
+  "pandas>=2.2.3, <3",
+  "btrack>=0.6.5, <1",
+  "click>=8.1.7, <9",
 ]
 description = "A package to convert track formats"
 dynamic = ["version"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,8 @@ classifiers = [
 ]
 dependencies = [
   "pandas",
-  "btrack"
+  "btrack",
+  "click"
 ]
 description = "A package to convert track formats"
 dynamic = ["version"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 dependencies = [
   "pandas",
   "btrack",
-  "click"
+  "click",
 ]
 description = "A package to convert track formats"
 dynamic = ["version"]

--- a/track_converter/src/convert_tracks.py
+++ b/track_converter/src/convert_tracks.py
@@ -109,7 +109,10 @@ def btrack(
     """
     _set_logging_config(verbose)
 
-    dead_track_list: list[int] = literal_eval(dead_track_ids)
+    if dead_track_ids is not None:
+        dead_track_list: list[int] = literal_eval(dead_track_ids)
+    else:
+        dead_track_list = None
 
     preprocess_btrack_file(
         Path(h5_path),
@@ -289,7 +292,10 @@ def ctc(
     """
     _set_logging_config(verbose)
 
-    dead_cells_list: list[int] = literal_eval(dead_cell_labels)
+    if dead_cell_labels is not None:
+        dead_cells_list: list[int] = literal_eval(dead_cell_labels)
+    else:
+        dead_cells_list = None
 
     preprocess_ctc_file(
         Path(input_txt_path),

--- a/track_converter/src/convert_tracks.py
+++ b/track_converter/src/convert_tracks.py
@@ -47,7 +47,7 @@ def _set_logging_config(verbose: bool = False) -> None:
 
 @click.group(cls=AliasedGroup)
 def convert_tracks() -> None:
-    """Overall CLI entry point - sub-commands for each file type are assigned to this group."""
+    """Convert/validate files from various cell tracking software."""
 
 
 @click.command()

--- a/track_converter/src/convert_tracks.py
+++ b/track_converter/src/convert_tracks.py
@@ -4,6 +4,7 @@ from typing import ClassVar
 import click
 
 from track_converter.src.preprocess_btrack import preprocess_btrack_file
+from track_converter.src.preprocess_mastodon import preprocess_mastodon_files
 from track_converter.src.preprocess_trackmate_or_mamut import preprocess_trackmate_or_mamut_files
 
 
@@ -129,7 +130,7 @@ def trackmate(
 
     TrackMate and MaMuT share the same output csv file formats and so can be processed in the
     same way. All cells that don't end in cell division will be marked as right-censored, except for (optionally)
-    those manually labelled as dead in with dead_label.
+    those manually labelled as dead with dead_label.
     """
     preprocess_trackmate_or_mamut_files(
         Path(spots_csv_path),
@@ -141,8 +142,59 @@ def trackmate(
     )
 
 
+@click.command()
+@click.argument("spots-csv-path")
+@click.argument("links-csv-path")
+@click.argument("output-txt-path")
+@click.option(
+    "--fix-late-daughters",
+    is_flag=True,
+    default=False,
+    help="Back-date any late daughters to the start time of the earlier daughter.",
+)
+@click.option(
+    "--fix-missing-daughters",
+    is_flag=True,
+    default=False,
+    help="Create a second daughter for any mother cells that only have one.",
+)
+@click.option(
+    "--dead-tagset",
+    help="Name of tagset for manually labelled 'dead' spots (dead_tag must also be provided)",
+)
+@click.option(
+    "--dead-tag",
+    help="Name of tag (inside dead-tagset) for manually labelled 'dead' spots (dead_tagset must also be provided)",
+)
+def mastodon(
+    spots_csv_path: str,
+    links_csv_path: str,
+    output_txt_path: str,
+    fix_late_daughters: bool,
+    fix_missing_daughters: bool,
+    dead_tagset: str,
+    dead_tag: str,
+) -> None:
+    """
+    Convert Mastodon csv files into a text file.
+
+    All cells that don't end in cell division will be marked as right-censored, except for (optionally) those manually
+    tagged as dead in Mastodon (indicated with dead_tagset and dead_tag).
+    """
+    preprocess_mastodon_files(
+        Path(spots_csv_path),
+        Path(links_csv_path),
+        Path(output_txt_path),
+        fix_late_daughters,
+        fix_missing_daughters,
+        dead_tagset,
+        dead_tag,
+    )
+
+
 convert_tracks.add_command(btrack)
 convert_tracks.add_command(trackmate)
+convert_tracks.add_command(mastodon)
 
 
 if __name__ == "__main__":

--- a/track_converter/src/convert_tracks.py
+++ b/track_converter/src/convert_tracks.py
@@ -1,3 +1,4 @@
+import logging
 from pathlib import Path
 from typing import ClassVar
 
@@ -30,6 +31,17 @@ class AliasedGroup(click.Group):
         commands = super().list_commands(ctx)
         commands.extend(self.aliases.keys())
         return commands
+
+
+def _set_logging_config(verbose: bool = False) -> None:
+    if verbose:
+        level = logging.INFO
+        logging.getLogger("btrack").setLevel(logging.INFO)
+    else:
+        level = logging.WARNING
+        logging.getLogger("btrack").setLevel(logging.WARNING)
+
+    logging.basicConfig(format="%(levelname)s: %(name)s: %(message)s", level=level, force=True)
 
 
 @click.group(cls=AliasedGroup)
@@ -70,6 +82,13 @@ def convert_tracks() -> None:
     type=int,
     help="List of track ids (.ID for each btrack Tracklet) to consider as 'dead' cells (i.e. not right-censored)",
 )
+@click.option(
+    "-v",
+    "--verbose",
+    is_flag=True,
+    default=False,
+    help="Verbose. Will print info messages as well as warnings / errors.",
+)
 def btrack(
     h5_path: str,
     output_txt_path: str,
@@ -78,6 +97,7 @@ def btrack(
     fix_late_daughters: bool,
     fix_missing_daughters: bool,
     dead_track_ids: tuple[int],
+    verbose: bool,
 ) -> None:
     """
     Convert a btrack output file (.h5) into a text file.
@@ -87,6 +107,8 @@ def btrack(
     options. With --no-terminate-fates, all cells that don't end in cell division will be marked as right-censored
     except for (optionally) those provided with --dead-track-ids.
     """
+    _set_logging_config(verbose)
+
     preprocess_btrack_file(
         Path(h5_path),
         Path(output_txt_path),
@@ -118,6 +140,13 @@ def btrack(
     "--dead-label",
     help="Name of manually labelled 'dead' spots (will be marked as not right-censored)",
 )
+@click.option(
+    "-v",
+    "--verbose",
+    is_flag=True,
+    default=False,
+    help="Verbose. Will print info messages as well as warnings / errors.",
+)
 def trackmate(
     spots_csv_path: str,
     edges_csv_path: str,
@@ -125,6 +154,7 @@ def trackmate(
     fix_late_daughters: bool,
     fix_missing_daughters: bool,
     dead_label: str,
+    verbose: bool,
 ) -> None:
     """
     Convert Trackmate or MaMuT csv files into a text file.
@@ -133,6 +163,8 @@ def trackmate(
     same way. All cells that don't end in cell division will be marked as right-censored, except for (optionally)
     those manually labelled as dead with dead_label.
     """
+    _set_logging_config(verbose)
+
     preprocess_trackmate_or_mamut_files(
         Path(spots_csv_path),
         Path(edges_csv_path),
@@ -167,6 +199,13 @@ def trackmate(
     "--dead-tag",
     help="Name of tag (inside dead-tagset) for manually labelled 'dead' spots (dead_tagset must also be provided)",
 )
+@click.option(
+    "-v",
+    "--verbose",
+    is_flag=True,
+    default=False,
+    help="Verbose. Will print info messages as well as warnings / errors.",
+)
 def mastodon(
     spots_csv_path: str,
     links_csv_path: str,
@@ -175,6 +214,7 @@ def mastodon(
     fix_missing_daughters: bool,
     dead_tagset: str,
     dead_tag: str,
+    verbose: bool,
 ) -> None:
     """
     Convert Mastodon csv files into a text file.
@@ -182,6 +222,8 @@ def mastodon(
     All cells that don't end in cell division will be marked as right-censored, except for (optionally) those manually
     tagged as dead in Mastodon (indicated with dead_tagset and dead_tag).
     """
+    _set_logging_config(verbose)
+
     preprocess_mastodon_files(
         Path(spots_csv_path),
         Path(links_csv_path),
@@ -220,6 +262,13 @@ def mastodon(
     type=int,
     help="List of cell labels to consider as dead cells (i.e mark as not right-censored)",
 )
+@click.option(
+    "-v",
+    "--verbose",
+    is_flag=True,
+    default=False,
+    help="Verbose. Will print info messages as well as warnings / errors.",
+)
 def ctc(
     input_txt_path: str,
     output_txt_path: str,
@@ -227,6 +276,7 @@ def ctc(
     fix_missing_daughters: bool,
     no_right_censor: bool,
     dead_cell_labels: tuple[int],
+    verbose: bool,
 ) -> None:
     """
     Validate a Cell Tracking Challenge (CTC) text file and save a new processed version.
@@ -236,6 +286,8 @@ def ctc(
     already contains a right-censoring column (5th column) then this will be used directly and any --no-right-censor /
     --dead-cell-labels ignored.
     """
+    _set_logging_config(verbose)
+
     preprocess_ctc_file(
         Path(input_txt_path),
         Path(output_txt_path),

--- a/track_converter/src/convert_tracks.py
+++ b/track_converter/src/convert_tracks.py
@@ -260,9 +260,8 @@ def mastodon(
 )
 @click.option(
     "--dead-cell-labels",
-    multiple=True,
-    type=int,
-    help="List of cell labels to consider as dead cells (i.e mark as not right-censored)",
+    help="""List of cell labels to consider as dead cells (i.e mark as not right-censored).
+    Must be provided in quotes - e.g. "[2, 5]" """,
 )
 @click.option(
     "-v",
@@ -277,7 +276,7 @@ def ctc(
     fix_late_daughters: bool,
     fix_missing_daughters: bool,
     no_right_censor: bool,
-    dead_cell_labels: tuple[int],
+    dead_cell_labels: str,
     verbose: bool,
 ) -> None:
     """
@@ -290,13 +289,15 @@ def ctc(
     """
     _set_logging_config(verbose)
 
+    dead_cells_list: list[int] = literal_eval(dead_cell_labels)
+
     preprocess_ctc_file(
         Path(input_txt_path),
         Path(output_txt_path),
         fix_late_daughters,
         fix_missing_daughters,
         not no_right_censor,
-        dead_cell_labels,
+        dead_cells_list,
     )
 
 

--- a/track_converter/src/convert_tracks.py
+++ b/track_converter/src/convert_tracks.py
@@ -1,4 +1,5 @@
 import logging
+from ast import literal_eval
 from pathlib import Path
 from typing import ClassVar
 
@@ -78,9 +79,8 @@ def convert_tracks() -> None:
 )
 @click.option(
     "--dead-track-ids",
-    multiple=True,
-    type=int,
-    help="List of track ids (.ID for each btrack Tracklet) to consider as 'dead' cells (i.e. not right-censored)",
+    help="""List of track ids (.ID for each btrack Tracklet) to consider as dead cells i.e. not right-censored. Must be
+    provided in quotes - e.g. "[1, 3, 5]" """,
 )
 @click.option(
     "-v",
@@ -96,7 +96,7 @@ def btrack(
     keep_false_positives: bool,
     fix_late_daughters: bool,
     fix_missing_daughters: bool,
-    dead_track_ids: tuple[int],
+    dead_track_ids: str,
     verbose: bool,
 ) -> None:
     """
@@ -109,6 +109,8 @@ def btrack(
     """
     _set_logging_config(verbose)
 
+    dead_track_list: list[int] = literal_eval(dead_track_ids)
+
     preprocess_btrack_file(
         Path(h5_path),
         Path(output_txt_path),
@@ -116,7 +118,7 @@ def btrack(
         not keep_false_positives,
         fix_late_daughters,
         fix_missing_daughters,
-        dead_track_ids,
+        dead_track_list,
     )
 
 

--- a/track_converter/src/convert_tracks.py
+++ b/track_converter/src/convert_tracks.py
@@ -1,11 +1,36 @@
 from pathlib import Path
+from typing import ClassVar
 
 import click
 
 from track_converter.src.preprocess_btrack import preprocess_btrack_file
+from track_converter.src.preprocess_trackmate_or_mamut import preprocess_trackmate_or_mamut_files
 
 
-@click.group()
+class AliasedGroup(click.Group):
+    """
+    Class to allow mamut as an alias to trackmate in the CLI.
+
+    Both software share the same csv files and so have identical options / processing.
+    """
+
+    aliases: ClassVar[dict[str, str]] = {"mamut": "trackmate"}
+
+    def get_command(self, ctx: click.Context, cmd_name: str) -> click.Command | None:
+        """Find the relevant Command object if it exists."""
+        if cmd_name in self.aliases:
+            cmd_name = self.aliases[cmd_name]
+
+        return super().get_command(ctx, cmd_name)
+
+    def list_commands(self, ctx: click.Context) -> list[str]:
+        """Return a list of subcommand names in the order they should appear in --help."""
+        commands = super().list_commands(ctx)
+        commands.extend(self.aliases.keys())
+        return commands
+
+
+@click.group(cls=AliasedGroup)
 def convert_tracks() -> None:
     """Overall CLI entry point - sub-commands for each file type are assigned to this group."""
 
@@ -16,7 +41,7 @@ def convert_tracks() -> None:
 @click.option(
     "--no-terminate-fates",
     is_flag=True,
-    default=True,
+    default=False,
     help="Don't use btrack's 'TERMINATE' fates to determine right-censoring",
 )
 @click.option(
@@ -71,7 +96,53 @@ def btrack(
     )
 
 
+@click.command()
+@click.argument("spots-csv-path")
+@click.argument("edges-csv-path")
+@click.argument("output-txt-path")
+@click.option(
+    "--fix-late-daughters",
+    is_flag=True,
+    default=False,
+    help="Back-date any late daughters to the start time of the earlier daughter.",
+)
+@click.option(
+    "--fix-missing-daughters",
+    is_flag=True,
+    default=False,
+    help="Create a second daughter for any mother cells that only have one.",
+)
+@click.option(
+    "--dead-label",
+    help="Name of manually labelled 'dead' spots (will be marked as not right-censored)",
+)
+def trackmate(
+    spots_csv_path: str,
+    edges_csv_path: str,
+    output_txt_path: str,
+    fix_late_daughters: bool,
+    fix_missing_daughters: bool,
+    dead_label: str,
+) -> None:
+    """
+    Convert Trackmate or MaMuT csv files into a text file.
+
+    TrackMate and MaMuT share the same output csv file formats and so can be processed in the
+    same way. All cells that don't end in cell division will be marked as right-censored, except for (optionally)
+    those manually labelled as dead in with dead_label.
+    """
+    preprocess_trackmate_or_mamut_files(
+        Path(spots_csv_path),
+        Path(edges_csv_path),
+        Path(output_txt_path),
+        fix_late_daughters,
+        fix_missing_daughters,
+        dead_label,
+    )
+
+
 convert_tracks.add_command(btrack)
+convert_tracks.add_command(trackmate)
 
 
 if __name__ == "__main__":

--- a/track_converter/src/convert_tracks.py
+++ b/track_converter/src/convert_tracks.py
@@ -1,0 +1,78 @@
+from pathlib import Path
+
+import click
+
+from track_converter.src.preprocess_btrack import preprocess_btrack_file
+
+
+@click.group()
+def convert_tracks() -> None:
+    """Overall CLI entry point - sub-commands for each file type are assigned to this group."""
+
+
+@click.command()
+@click.argument("h5-path")
+@click.argument("output-txt-path")
+@click.option(
+    "--no-terminate-fates",
+    is_flag=True,
+    default=True,
+    help="Don't use btrack's 'TERMINATE' fates to determine right-censoring",
+)
+@click.option(
+    "--keep-false-positives",
+    is_flag=True,
+    default=False,
+    help="Keep cells with a btrack fate of FALSE_POSITIVE",
+)
+@click.option(
+    "--fix-late-daughters",
+    is_flag=True,
+    default=False,
+    help="Back-date any late daughters to the start time of the earlier daughter.",
+)
+@click.option(
+    "--fix-missing-daughters",
+    is_flag=True,
+    default=False,
+    help="Create a second daughter for any mother cells that only have one.",
+)
+@click.option(
+    "--dead-track-ids",
+    multiple=True,
+    type=int,
+    help="List of track ids (.ID for each btrack Tracklet) to consider as 'dead' cells (i.e. not right-censored)",
+)
+def btrack(
+    h5_path: str,
+    output_txt_path: str,
+    no_terminate_fates: bool,
+    keep_false_positives: bool,
+    fix_late_daughters: bool,
+    fix_missing_daughters: bool,
+    dead_track_ids: tuple[int],
+) -> None:
+    """
+    Convert a btrack output file (.h5) into a text file.
+
+    By default, all right censoring information will be read directly from btrack's assigned 'fates' and cells with
+    'false positive' fates will be removed. To disable this, use the --no-terminate-fates and --keep-false-positives
+    options. With --no-terminate-fates, all cells that don't end in cell division will be marked as right-censored
+    except for (optionally) those provided with --dead-track-ids.
+    """
+    preprocess_btrack_file(
+        Path(h5_path),
+        Path(output_txt_path),
+        not no_terminate_fates,
+        not keep_false_positives,
+        fix_late_daughters,
+        fix_missing_daughters,
+        dead_track_ids,
+    )
+
+
+convert_tracks.add_command(btrack)
+
+
+if __name__ == "__main__":
+    convert_tracks()

--- a/track_converter/src/preprocess_btrack.py
+++ b/track_converter/src/preprocess_btrack.py
@@ -1,4 +1,5 @@
 import logging
+from collections.abc import Iterable
 from pathlib import Path
 
 import pandas as pd
@@ -51,7 +52,7 @@ def _discard_false_positives(tracks: list[Tracklet], ctc_table: pd.DataFrame) ->
     return ctc_table
 
 
-def _validate_dead_track_ids(ctc_table: pd.DataFrame, dead_track_ids: list[int]) -> None:
+def _validate_dead_track_ids(ctc_table: pd.DataFrame, dead_track_ids: Iterable[int]) -> None:
     # check all dead_track_ids appear in the table (L)
     dead_ids_series = pd.Series(dead_track_ids)
     ids_are_valid = dead_ids_series.isin(ctc_table.L)
@@ -80,7 +81,7 @@ def preprocess_btrack_file(
     remove_false_positives: bool = True,
     fix_late_daughters: bool = False,
     fix_missing_daughters: bool = False,
-    dead_track_ids: list[int] | None = None,
+    dead_track_ids: Iterable[int] | None = None,
 ) -> None:
     """
     Preprocess btrack format (.h5) file.
@@ -105,7 +106,7 @@ def preprocess_btrack_file(
         Whether to back-date any late daughters to the start time of the earlier daughter.
     fix_missing_daughters : bool, optional
         Whether to create a second daughter for any mother cells that only have one.
-    dead_track_ids : list[int] | None
+    dead_track_ids : Iterable[int] | None
         List of track ids (accessed via .ID for each btrack Tracklet) to consider as 'dead' cells. These will be
         marked as not right-censored.
 

--- a/track_converter/src/preprocess_ctc.py
+++ b/track_converter/src/preprocess_ctc.py
@@ -246,12 +246,14 @@ def _right_censor_non_dividing_cells(tracks: pd.DataFrame) -> pd.DataFrame:
     tracks.loc[cells_with_daughters, "R"] = 0
     tracks.loc[~cells_with_daughters, "R"] = 1
 
+    logger.info("Marking all tracks that don't end in cell division as right-censored... Passed")
     return tracks
 
 
 def _mark_dead_cells_as_not_right_censored(tracks: pd.DataFrame, dead_cell_labels: Iterable[int]) -> pd.DataFrame:
     tracks.loc[tracks.L.isin(dead_cell_labels), "R"] = 0
 
+    logger.info("Marking dead_cell_labels as not right-censored... Passed")
     return tracks
 
 

--- a/track_converter/src/preprocess_ctc.py
+++ b/track_converter/src/preprocess_ctc.py
@@ -1,4 +1,5 @@
 import logging
+from collections.abc import Iterable
 from pathlib import Path
 
 import pandas as pd
@@ -248,7 +249,7 @@ def _right_censor_non_dividing_cells(tracks: pd.DataFrame) -> pd.DataFrame:
     return tracks
 
 
-def _mark_dead_cells_as_not_right_censored(tracks: pd.DataFrame, dead_cell_labels: list[int]) -> pd.DataFrame:
+def _mark_dead_cells_as_not_right_censored(tracks: pd.DataFrame, dead_cell_labels: Iterable[int]) -> pd.DataFrame:
     tracks.loc[tracks.L.isin(dead_cell_labels), "R"] = 0
 
     return tracks
@@ -260,7 +261,7 @@ def preprocess_ctc_file(
     fix_late_daughters: bool = False,
     fix_missing_daughters: bool = False,
     default_right_censor: bool = True,
-    dead_cell_labels: list[int] | None = None,
+    dead_cell_labels: Iterable[int] | None = None,
 ) -> None:
     """
     Preprocess Cell Tracking Challenge (CTC) format files.
@@ -289,7 +290,7 @@ def preprocess_ctc_file(
         Whether to right censor all cell tracks that don't end in cell division. Any cells provided as
         'dead_cell_labels' will be excluded from this. Note that if your input CTC file already contains a
         right-censoring column (5th column) this setting will be ignored.
-    dead_cell_labels : list[int] | None, optional
+    dead_cell_labels : Iterable[int] | None, optional
         List of cell labels (L) to consider as dead cells (i.e mark as not right-censored). Note that if your input
         CTC file already contains a right-censoring column (5th column) this setting will be ignored.
 

--- a/track_converter/tests/test_cli.py
+++ b/track_converter/tests/test_cli.py
@@ -125,3 +125,38 @@ def test_mastodon_cli(mastodon_test_data_dir, tracks_out_path):
             dead_tagset="dead_cells",
             dead_tag="dead",
         )
+
+
+def test_ctc_cli(ctc_test_data_dir, tracks_out_path):
+    """Test CLI call to CTC calls preprocess_ctc_file with correct parameters."""
+    runner = CliRunner()
+
+    with mock.patch("track_converter.src.convert_tracks.preprocess_ctc_file", autospec=True) as preprocess_ctc_file:
+        input_txt_path = ctc_test_data_dir / "tracks_two_trees.txt"
+        input_txt_str = str(input_txt_path.resolve())
+        output_path_str = str(tracks_out_path.resolve())
+
+        result = runner.invoke(
+            convert_tracks,
+            [
+                "ctc",
+                input_txt_str,
+                output_path_str,
+                "--fix-late-daughters",
+                "--fix-missing-daughters",
+                "--no-right-censor",
+                "--dead-cell-labels",
+                "[2, 5]",
+                "-v",
+            ],
+        )
+
+        assert result.exit_code == 0
+        preprocess_ctc_file.assert_called_once_with(
+            input_txt_path,
+            tracks_out_path,
+            fix_late_daughters=True,
+            fix_missing_daughters=True,
+            default_right_censor=False,
+            dead_cell_labels=[2, 5],
+        )

--- a/track_converter/tests/test_cli.py
+++ b/track_converter/tests/test_cli.py
@@ -1,0 +1,44 @@
+from unittest import mock
+
+from click.testing import CliRunner
+
+from track_converter.src.convert_tracks import convert_tracks
+
+
+def test_btrack_cli(btrack_test_data_dir, tracks_out_path):
+    """Test CLI call to btrack calls preprocess_btrack_file with correct parameters."""
+    runner = CliRunner()
+
+    with mock.patch(
+        "track_converter.src.convert_tracks.preprocess_btrack_file", autospec=True
+    ) as preprocess_btrack_file:
+        input_path = btrack_test_data_dir / "tracks.h5"
+        input_path_str = str(input_path.resolve())
+        output_path_str = str(tracks_out_path.resolve())
+
+        result = runner.invoke(
+            convert_tracks,
+            [
+                "btrack",
+                input_path_str,
+                output_path_str,
+                "--no-terminate-fates",
+                "--keep-false-positives",
+                "--fix-late-daughters",
+                "--fix-missing-daughters",
+                "--dead-track-ids",
+                "[53, 49, 38]",
+                "-v",
+            ],
+        )
+
+        assert result.exit_code == 0
+        preprocess_btrack_file.assert_called_once_with(
+            input_path,
+            tracks_out_path,
+            use_terminate_fates=False,
+            remove_false_positives=False,
+            fix_late_daughters=True,
+            fix_missing_daughters=True,
+            dead_track_ids=[53, 49, 38],
+        )

--- a/track_converter/tests/test_cli.py
+++ b/track_converter/tests/test_cli.py
@@ -47,7 +47,7 @@ def test_btrack_cli(btrack_test_data_dir, tracks_out_path):
 
 @pytest.mark.parametrize("tracking_software", ["trackmate", "mamut"])
 def test_trackmate_mamut_cli(tracking_software, trackmate_test_data_dir, tracks_out_path):
-    """Test CLI call to btrack calls preprocess_btrack_file with correct parameters."""
+    """Test CLI call to trackmate/mamut calls preprocess_trackmate_or_mamut_files with correct parameters."""
     runner = CliRunner()
 
     with mock.patch(
@@ -82,4 +82,46 @@ def test_trackmate_mamut_cli(tracking_software, trackmate_test_data_dir, tracks_
             fix_late_daughters=True,
             fix_missing_daughters=True,
             dead_label="dead",
+        )
+
+
+def test_mastodon_cli(mastodon_test_data_dir, tracks_out_path):
+    """Test CLI call to mastodon calls preprocess_mastodon_files with correct parameters."""
+    runner = CliRunner()
+
+    with mock.patch(
+        "track_converter.src.convert_tracks.preprocess_mastodon_files", autospec=True
+    ) as preprocess_mastodon_files:
+        input_spot_path = mastodon_test_data_dir / "MastodonTable-Spot.csv"
+        input_link_path = mastodon_test_data_dir / "MastodonTable-Link.csv"
+        input_spot_str = str(input_spot_path.resolve())
+        input_link_str = str(input_link_path.resolve())
+        output_path_str = str(tracks_out_path.resolve())
+
+        result = runner.invoke(
+            convert_tracks,
+            [
+                "mastodon",
+                input_spot_str,
+                input_link_str,
+                output_path_str,
+                "--fix-late-daughters",
+                "--fix-missing-daughters",
+                "--dead-tagset",
+                "dead_cells",
+                "--dead-tag",
+                "dead",
+                "-v",
+            ],
+        )
+
+        assert result.exit_code == 0
+        preprocess_mastodon_files.assert_called_once_with(
+            input_spot_path,
+            input_link_path,
+            tracks_out_path,
+            fix_late_daughters=True,
+            fix_missing_daughters=True,
+            dead_tagset="dead_cells",
+            dead_tag="dead",
         )


### PR DESCRIPTION
This PR adds a `click` command line interface for the track conversion code (+ tests + documentation on how to use it)

See the nicely formatted documentation [on the track_converter_cli branch](https://github.com/K-Meech/Lineage-analysis/blob/km/track_converter_cli/docs/tracking_formats.md) (CLI information is at the bottom)

@pembacher - let me know if anything needs changing here, or if you want to discuss any of the code changes 